### PR TITLE
Use the view prop instead of watching some other props

### DIFF
--- a/app/interactions/draw.tsx
+++ b/app/interactions/draw.tsx
@@ -15,14 +15,15 @@ export class Draw extends React.Component<any, any> {
   constructor(props) {
     super(props);
     this.state = {
-      zoom: 4,
-      center: [-11000000, 4600000],
+      view: {
+        zoom: 4,
+        center: [-11000000, 4600000],
+      }
     };
     this.drawend = this.drawend.bind(this);
   }
 
   drawend(e) {
-    this.setState({ center: [0,0] });
     console.log('xxxxxxxxxxxxx, draw end', e);
   }
 
@@ -30,7 +31,7 @@ export class Draw extends React.Component<any, any> {
     var typeSelect = document.getElementById('type');
     return (
       <div>
-        <Map view={{center: [-11000000, 4600000], zoom: 4}} setCenter={ this.state.center }>
+        <Map view={this.state.view}>
           <Layers>
             <layer.Tile source={rasterTile} />
             <layer.Vector source={vectorSource} />

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "start": "NODE_ENV=dev webpack-dev-server --quiet --port 9001 --content-base app --config app/webpack.config --open",
+    "start": "cross-env NODE_ENV=dev webpack-dev-server --quiet --port 9001 --content-base app --config app/webpack.config --open",
     "clean": "rimraf dist",
     "build": "npm-run-all --serial clean build:umd build:app",
-    "build:umd": "NODE_ENV=prod webpack",
-    "build:app": "NODE_ENV=prod webpack --config app/webpack.config",
+    "build:umd": "cross-env NODE_ENV=prod webpack",
+    "build:app": "cross-env NODE_ENV=prod webpack --config app/webpack.config",
     "upgrade": "npm-check-updates -a/--upgradeAll && npm i"
   },
   "repository": {
@@ -65,6 +65,7 @@
   },
   "dependencies": {
     "@types/googlemaps": "^3.26.4",
+    "cross-env": "^4.0.0",
     "google-maps": "^3.2.1",
     "ol-mapbox-style": "^2.1.1",
     "qwest": "^4.4.5",

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -104,10 +104,10 @@ export class Map extends React.Component<any, any> {
   /* Modified by Harinder Randhawa */
   componentWillReceiveProps(nextProps) {
     let options = Util.getOptions(Object.assign(this.options, nextProps));
-    if(nextProps.setCenter !== this.props.view.center){
+    if(this.props.view && nextProps.setCenter !== this.props.view.center){
       this.map.getView().setCenter(nextProps.setCenter);
     }
-    if(nextProps.setZoom !== this.props.view.zoom){
+    if(this.props.view && nextProps.setZoom !== this.props.view.zoom){
       this.map.getView().setZoom(nextProps.setZoom);
     }
  }

--- a/src/map.tsx
+++ b/src/map.tsx
@@ -103,12 +103,11 @@ export class Map extends React.Component<any, any> {
   // update the view with new props
   /* Modified by Harinder Randhawa */
   componentWillReceiveProps(nextProps) {
-    let options = Util.getOptions(Object.assign(this.options, nextProps));
-    if(this.props.view && nextProps.setCenter !== this.props.view.center){
-      this.map.getView().setCenter(nextProps.setCenter);
+    if(this.props.view && nextProps.view.center !== this.props.view.center){
+      this.map.getView().setCenter(nextProps.view.center);
     }
-    if(this.props.view && nextProps.setZoom !== this.props.view.zoom){
-      this.map.getView().setZoom(nextProps.setZoom);
+    if(this.props.view && nextProps.view.zoom !== this.props.view.zoom){
+      this.map.getView().setZoom(nextProps.view.zoom);
     }
  }
   render() {


### PR DESCRIPTION
See #12.

If anyone's wondering, the cross-env package won't affect the previous usability of the commands, just makes it work for us who use Windows.