### PR TITLE
Fix findChild occurences for minified code

### DIFF
--- a/src/map.tsx
+++ b/src/map.tsx
@@ -6,6 +6,8 @@ import {layer} from './layers/index';
 
 import './ol.css';
 import './map.css';
+import {Controls} from "./controls";
+import {Interactions} from "./interactions";
 
 /**
  * Implementation of ol.map https://openlayers.org/en/latest/apidoc/ol.Map.html
@@ -81,8 +83,8 @@ export class Map extends React.Component<any, any> {
     let options = Util.getOptions(Object.assign(this.options, this.props));
     !(options.view instanceof ol.View) && (options.view = new ol.View(options.view));
 
-    let controlsCmp = Util.findChild(this.props.children, 'Controls') || {};
-    let interactionsCmp = Util.findChild(this.props.children, 'Interactions') || {};
+    let controlsCmp = Util.findChild(this.props.children, Controls) || {};
+    let interactionsCmp = Util.findChild(this.props.children, Interactions) || {};
 
     options.controls = ol.control.defaults(controlsCmp.props).extend(this.controls);
     options.interactions = ol.interaction.defaults(interactionsCmp.props).extend(this.interactions);

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -58,12 +58,12 @@ function cloneObject(obj){
   return obj;
 }
 
-function findChild(children: any[], childType: string) {
+function findChild(children: any[], childType: any) {
   let found: any;
   let childrenArr = React.Children.toArray(children);
   for (let i=0; i<childrenArr.length; i++) {
     let child: any = childrenArr[i];
-    if (child.type.name == childType){
+    if (child.type == childType){
       found = child;
       break;
     }


### PR DESCRIPTION
The name of stateless components is equal to the function name, which might get lost during minification. This changes the code to compare the types by value rather than their name.

You're probably not maintaining this fork anymore but I thought it was worthwhile to at least put my changes out there.